### PR TITLE
CD-227790 Upgrade redis-namespace gem in order to update redis-rb gem to support tls

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -110,8 +110,8 @@ module Resque
   def redis=(server)
     case server
     when String
-      if server =~ /redis\:\/\//
-        redis = Redis.connect(:url => server, :thread_safe => true)
+      if server =~ /rediss?\:\/\//
+        redis = Redis.new(:url => server, :thread_safe => true)
       else
         server, namespace = server.split('/', 2)
         host, port, db = server.split(':')
@@ -145,7 +145,7 @@ module Resque
     elsif redis.respond_to?(:nodes) # distributed
       redis.nodes.map { |n| n.id }.join(', ')
     else
-      redis.client.id
+      redis._client.id
     end
   end
 

--- a/lib/resque/version.rb
+++ b/lib/resque/version.rb
@@ -1,3 +1,3 @@
 module Resque
-  Version = VERSION = '1.26.0'
+  Version = VERSION = '1.26.0.1'
 end

--- a/lib/resque/worker.rb
+++ b/lib/resque/worker.rb
@@ -324,7 +324,7 @@ module Resque
     def reconnect
       tries = 0
       begin
-        redis.client.reconnect
+        redis._client.reconnect
       rescue Redis::BaseConnectionError
         if (tries += 1) <= 3
           log_with_severity :error, "Error reconnecting to Redis; retrying"

--- a/resque.gemspec
+++ b/resque.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files  = [ "LICENSE", "README.markdown" ]
   s.rdoc_options      = ["--charset=UTF-8"]
 
-  s.add_dependency "redis-namespace", "~> 1.3"
+  s.add_dependency "redis-namespace", "~> 1.6"
   s.add_dependency "vegas", "~> 0.1.2"
   s.add_dependency "sinatra", ">= 0.9.2"
   s.add_dependency "multi_json", "~> 1.0"

--- a/test/child_killing_test.rb
+++ b/test/child_killing_test.rb
@@ -7,7 +7,7 @@ describe "Resque::Worker" do
     @queue = :long_running_job
 
     def self.perform( sleep_time, rescue_time=nil )
-      Resque.redis.client.reconnect # get its own connection
+      Resque.redis._client.reconnect # get its own connection
       Resque.redis.rpush( 'sigterm-test:start', Process.pid )
       sleep sleep_time
       Resque.redis.rpush( 'sigterm-test:result', 'Finished Normally' )
@@ -24,7 +24,7 @@ describe "Resque::Worker" do
 
     worker_pid = Kernel.fork do
       # reconnect since we just forked
-      Resque.redis.client.reconnect
+      Resque.redis._client.reconnect
 
       worker = Resque::Worker.new(:long_running_job)
       worker.term_timeout = term_timeout


### PR DESCRIPTION
## Reviewers

- [ ] @johnny-lai 
- [x] @abdulchaudhrycoupa 


## Summary of change

 - Updated `redis-namespace` gem to `v1.6` which supports redis-rb v4.
 - Changes wrt redis-rb
     - redis.client is changed to redis._client 
     https://github.com/resque/redis-namespace/commit/1403f511f6ae1ec9a8f330298a4cacf73fb10afc 
     https://github.com/redis/redis-rb/commit/c239abb43c2dce99468bf94652a3c48b31a1041a
     
   - Redis.connect is changed to Redis.new 
   https://github.com/redis/redis-rb/commit/895cc3211e335a8fd9ba9322cd311c09eea9621f
   