### PR TITLE
CD-234432 Update Resque.redis with worker's redis in stats and other places

### DIFF
--- a/lib/resque.rb
+++ b/lib/resque.rb
@@ -512,7 +512,7 @@ module Resque
   def info
     return {
       :pending   => queue_sizes.inject(0) { |sum, (queue_name, queue_size)| sum + queue_size },
-      :processed => Stat[:processed],
+      :processed => Stat.get(Resque.redis, :processed),
       :queues    => queues.size,
       :workers   => workers.size.to_i,
       :working   => working.size,

--- a/lib/resque/failure/redis.rb
+++ b/lib/resque/failure/redis.rb
@@ -14,7 +14,7 @@ module Resque
           :queue     => queue
         }
         data = Resque.encode(data)
-        Resque.redis.rpush(:failed, data)
+        worker.class.redis.rpush(:failed, data)
       end
 
       def self.count(queue = nil, class_name = nil)

--- a/lib/resque/stat.rb
+++ b/lib/resque/stat.rb
@@ -7,50 +7,35 @@ module Resque
   #   Kill a stat: Stat.clear(name)
   module Stat
     extend self
-    
-    # Direct access to the Redis instance.
-    def redis
-      Resque.redis
-    end
 
     # Returns the int value of a stat, given a string stat name.
-    def get(stat)
+    def get(redis, stat)
       redis.get("stat:#{stat}").to_i
     end
 
     # Alias of `get`
-    def [](stat)
-      get(stat)
+    def [](redis, stat)
+      get(redis, stat)
     end
 
     # For a string stat name, increments the stat by one.
     #
     # Can optionally accept a second int parameter. The stat is then
     # incremented by that amount.
-    def incr(stat, by = 1)
+    def incr(redis, stat, by = 1)
       redis.incrby("stat:#{stat}", by)
-    end
-
-    # Increments a stat by one.
-    def <<(stat)
-      incr stat
     end
 
     # For a string stat name, decrements the stat by one.
     #
     # Can optionally accept a second int parameter. The stat is then
     # decremented by that amount.
-    def decr(stat, by = 1)
+    def decr(redis, stat, by = 1)
       redis.decrby("stat:#{stat}", by)
     end
 
-    # Decrements a stat by one.
-    def >>(stat)
-      decr stat
-    end
-
     # Removes a stat from Redis, effectively setting it to 0.
-    def clear(stat)
+    def clear(redis, stat)
       redis.del("stat:#{stat}")
     end
   end


### PR DESCRIPTION
## Reviewers

-  [ ] @johnny-lai 

## Summary of Change

 - Pass `redis` as an argument to Stat as it can point to redis v3 or redis v6
 - Changed `Resque.redis` with worker redis in other minor places